### PR TITLE
ui2 - compare careers layout

### DIFF
--- a/client/controllers.js
+++ b/client/controllers.js
@@ -231,7 +231,6 @@ function($scope, $meteor, $stateParams, $state, $window, $rootScope, $location, 
     $meteor.autorun($scope, function() {
         $meteor.subscribe('careerProfileResults', $stateParams.careerId).then(function(sub) {
             $scope.career = $meteor.object(Careers, {_id: $stateParams.careerId});
-            console.log($scope.career);
         });
     });
 
@@ -398,7 +397,7 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
             $scope.skillsIntersect = _.intersection($scope.skills1, $scope.skills2);
             $scope.skills1 = _.xor($scope.skills1, $scope.skillsIntersect);
             $scope.skills2 = _.xor($scope.skills2, $scope.skillsIntersect);
-            
+
         });
 
     });

--- a/client/controllers.js
+++ b/client/controllers.js
@@ -398,7 +398,7 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
             $scope.skillsIntersect = _.intersection($scope.skills1, $scope.skills2);
             $scope.skills1 = _.xor($scope.skills1, $scope.skillsIntersect);
             $scope.skills2 = _.xor($scope.skills2, $scope.skillsIntersect);
-
+            
         });
 
     });

--- a/client/controllers.js
+++ b/client/controllers.js
@@ -382,8 +382,8 @@ function($scope, $meteor, $stateParams, $state, $window, $rootScope, $location, 
 // CompareViewController
 // ***********************************
 angular.module('reflectivePath').controller('CompareViewController', ['$scope', '$meteor',
- '$stateParams', '$window',
-function($scope, $meteor, $stateParams, $window){
+ '$stateParams', '$window', '$rootScope', '$location', '$anchorScroll',
+function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorScroll){
 
     $meteor.autorun($scope, function() {
         $meteor.subscribe('careerCompareResults', $stateParams.careerId1, $stateParams.careerId2).then(function(sub) {

--- a/client/controllers.js
+++ b/client/controllers.js
@@ -401,9 +401,9 @@ function($scope, $meteor, $stateParams, $state, $window, $rootScope, $location, 
 
     $scope.createUrlString = function(string, glassdoorString) {
         if (glassdoorString) {
-            var urlString = string.replace(' ', '-');
+            var urlString = string.split(' ').join('-');
         } else {
-        var urlString = string.replace(' ', '+');
+        var urlString = string.replace(' ').join('+');
         }
         return urlString
    }

--- a/client/controllers.js
+++ b/client/controllers.js
@@ -389,7 +389,18 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
         $meteor.subscribe('careerCompareResults', $stateParams.careerId1, $stateParams.careerId2).then(function(sub) {
             $scope.career1 = $meteor.object(Careers, {_id: $stateParams.careerId1});
             $scope.career2 = $meteor.object(Careers, {_id: $stateParams.careerId2});
+
+            // get top 20 skills for each career
+            $scope.skills1 = _.pluck(_.sortBy($scope.career1.skills, -'count').slice(0,20), 'name');
+            $scope.skills2 = _.pluck(_.sortBy($scope.career2.skills, -'count').slice(0,20), 'name');
+
+            // get intersecting and unique skills
+            $scope.skillsIntersect = _.intersection($scope.skills1, $scope.skills2);
+            $scope.skills1 = _.xor($scope.skills1, $scope.skillsIntersect);
+            $scope.skills2 = _.xor($scope.skills2, $scope.skillsIntersect);
+
         });
+
     });
 
     //**** QUERYING BY TAG ****

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -122,7 +122,7 @@
             <ul>
                 <li ng-repeat="category in career1.categories | limitTo: 10" >
                   <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
-                    {{category.name}} {{category.count}}
+                    {{category.name}}
                   </a>
                 </li>
             </ul>
@@ -133,7 +133,7 @@
             <ul>
                 <li ng-repeat="category in career2.categories | limitTo: 10" >
                   <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
-                    {{category.name}} {{category.count}}
+                    {{category.name}}
                   </a>
                 </li>
             </ul>

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -40,33 +40,33 @@
             <h5 class="anchor" id="anchor-activities">ACTIVITIES</h5>
           </div>
 
-          <div class="col-xs-6 subSection border-right col-left" ng-init="activityLimit1 = 4">
+          <div class="col-xs-6 subSection border-right col-left" ng-init="activityLimit = 4">
             <ul>
-              <li ng-repeat="activity in career1.work_activities.activities | limitTo: activityLimit1" class="longListItem">
+              <li ng-repeat="activity in career1.work_activities.activities | limitTo: activityLimit" class="longListItem">
                 {{activity}}
               </li>
             </ul>
-            <a role="button" class="showMoreCareerInfo" ng-hide="career1.work_activities.activities.length <= activityLimit1" ng-click="activityLimit1 = career1.work_activities.activities.length">
+            <a role="button" class="showMoreCareerInfo" ng-hide="career1.work_activities.activities.length <= activityLimit" ng-click="activityLimit = 30">
               show all activities
               <span class="fa fa-chevron-down"></span>
             </a>
-            <a href="#anchor-activities" role="button" class="showMoreCareerInfo" ng-show="career1.work_activities.activities.length === activityLimit1" ng-click="activityLimit1 = 4">
+            <a href="#anchor-activities" role="button" class="showMoreCareerInfo" ng-show="activityLimit == 30" ng-click="activityLimit = 4">
               show fewer activities
               <span class="fa fa-chevron-up"></span>
             </a>
           </div>
 
-          <div class="col-xs-6 subSection border-left col-right" ng-init="activityLimit2 = 4">
+          <div class="col-xs-6 subSection border-left col-right" ng-init="activityLimit = 4">
             <ul>
-              <li ng-repeat="activity in career2.work_activities.activities | limitTo: activityLimit2" class="longListItem">
+              <li ng-repeat="activity in career2.work_activities.activities | limitTo: activityLimit" class="longListItem">
                 {{activity}}
               </li>
             </ul>
-            <a role="button" class="showMoreCareerInfo" ng-hide="career2.work_activities.activities.length <= activityLimit2" ng-click="activityLimit2 = career2.work_activities.activities.length">
+            <a role="button" class="showMoreCareerInfo" ng-hide="career2.work_activities.activities.length <= activityLimit" ng-click="activityLimit = 30">
               show all activities
               <span class="fa fa-chevron-down"></span>
             </a>  
-            <a href="#anchor-activities" role="button" class="showMoreCareerInfo" ng-show="career2.work_activities.activities.length === activityLimit2" ng-click="activityLimit2 = 4">
+            <a href="#anchor-activities" role="button" class="showMoreCareerInfo" ng-show="activityLimit == 30" ng-click="activityLimit = 4">
               show fewer activities
               <span class="fa fa-chevron-up"></span>
             </a>
@@ -79,24 +79,31 @@
           <div class="col-xs-12">
             <h5>SKILLS</h5>
           </div>
-          <div class="col-xs-4 subSection  col-left">
+
+          <div class="col-xs-4 subSection col-left text-center">
+            <p>{{career1.standardized_title}}</p>
             <ul>
                 <li ng-repeat="skill in career1.skills | orderBy: '-count' | limitTo: 20">
                   {{skill.name}} ({{skill.count}})</li>
             </ul>
           </div>
-          <div class="col-xs-4 subSection col-right">
+
+          <div class="col-xs-4 subSection col-left col-mid text-center" ng-init="intersection = skillIntersection(career1.skills, career2.skills)">
+            <p>Shared Skills</p>
+            <ul>
+                <li ng-repeat="skill in intersection | orderBy: '-count' | limitTo: 20">
+                  {{skill.name}} ({{skill.count}})</li>
+            </ul>
+          </div>
+
+          <div class="col-xs-4 subSection col-right text-center">
+            <p>{{career2.standardized_title}}</p>
             <ul>
                 <li ng-repeat="skill in career2.skills | orderBy: '-count' | limitTo: 20">
                   {{skill.name}} ({{skill.count}})</li>
             </ul>
           </div>
-          <div class="col-xs-4 subSection  col-right">
-            <ul>
-                <li ng-repeat="skill in career2.skills | orderBy: '-count' | limitTo: 20">
-                  {{skill.name}} ({{skill.count}})</li>
-            </ul>
-          </div>
+
         </div>
 
         <!-- INDUSTRIES -->
@@ -130,16 +137,16 @@
             <h5 class="anchor" id="anchor-context">WORK CONTEXT</h5>
           </div>
 
-          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit1 = 4">
+          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit = 4">
             <ul>
-              <li ng-repeat="context in career1.work_context.top_work_contexts | limitTo: contextLimit1" class="longListItem">
+              <li ng-repeat="context in career1.work_context.top_work_contexts | limitTo: contextLimit" class="longListItem">
                 {{context}}</li>
             </ul>
-            <a role="button" class="showMoreCareerInfo" ng-hide="career1.work_context.top_work_contexts.length <= contextLimit1" ng-click="contextLimit1 = career1.work_activities.activities.length">
+            <a role="button" class="showMoreCareerInfo" ng-hide="career1.work_context.top_work_contexts.length <= contextLimit" ng-click="contextLimit = 20">
               show more
               <span class="fa fa-chevron-down"></span>
             </a>
-            <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit1 === career1.work_activities.activities.length" ng-click="contextLimit1 = 4">
+            <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit == 20" ng-click="contextLimit = 4">
               show less
               <span class="fa fa-chevron-up"></span>
             </a>
@@ -154,16 +161,16 @@
             </div>
           </div>
 
-          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit2 = 4">
+          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit = 4">
             <ul>
-              <li ng-repeat="context in career2.work_context.top_work_contexts | limitTo: contextLimit2" class="longListItem">
+              <li ng-repeat="context in career2.work_context.top_work_contexts | limitTo: contextLimit" class="longListItem">
                 {{context}}</li>
             </ul>
-            <a role="button" class="showMoreCareerInfo" ng-hide="career2.work_context.top_work_contexts.length <= contextLimit2" ng-click="contextLimit2 = career2.work_activities.activities.length">
+            <a role="button" class="showMoreCareerInfo" ng-hide="career2.work_context.top_work_contexts.length <= contextLimit" ng-click="contextLimit = 20">
               show more
               <span class="fa fa-chevron-down"></span>
             </a>
-            <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit2 === career2.work_activities.activities.length" ng-click="contextLimit2 = 4">
+            <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit == 20" ng-click="contextLimit = 4">
               show less
               <span class="fa fa-chevron-up"></span>
             </a>

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -37,22 +37,41 @@
         <!-- ACTIVITIES -->
         <div class="row">
           <div class="col-xs-12">
-            <h5>ACTIVITIES</h5>
+            <h5 class="anchor" id="anchor-activities">ACTIVITIES</h5>
           </div>
-          <div class="col-xs-6 subSection border-right col-left">
+
+          <div class="col-xs-6 subSection border-right col-left" ng-init="activityLimit1 = 4">
             <ul>
-              <li ng-repeat="activity in career1.work_activities.activities" class="longListItem">
+              <li ng-repeat="activity in career1.work_activities.activities | limitTo: activityLimit1" class="longListItem">
                 {{activity}}
               </li>
             </ul>
+            <a role="button" class="showMoreCareerInfo" ng-hide="career1.work_activities.activities.length <= activityLimit1" ng-click="activityLimit1 = career1.work_activities.activities.length">
+              show all activities
+              <span class="fa fa-chevron-down"></span>
+            </a>
+            <a href="#anchor-activities" role="button" class="showMoreCareerInfo" ng-show="career1.work_activities.activities.length === activityLimit1" ng-click="activityLimit1 = 4">
+              show fewer activities
+              <span class="fa fa-chevron-up"></span>
+            </a>
           </div>
-          <div class="col-xs-6 subSection border-left col-right">
+
+          <div class="col-xs-6 subSection border-left col-right" ng-init="activityLimit2 = 4">
             <ul>
-              <li ng-repeat="activity in career2.work_activities.activities" class="longListItem">
+              <li ng-repeat="activity in career2.work_activities.activities | limitTo: activityLimit2" class="longListItem">
                 {{activity}}
               </li>
             </ul>
+            <a role="button" class="showMoreCareerInfo" ng-hide="career2.work_activities.activities.length <= activityLimit2" ng-click="activityLimit2 = career2.work_activities.activities.length">
+              show all activities
+              <span class="fa fa-chevron-down"></span>
+            </a>  
+            <a href="#anchor-activities" role="button" class="showMoreCareerInfo" ng-show="career2.work_activities.activities.length === activityLimit2" ng-click="activityLimit2 = 4">
+              show fewer activities
+              <span class="fa fa-chevron-up"></span>
+            </a>
           </div>
+
         </div>
 
         <!-- SKILLS -->
@@ -60,13 +79,19 @@
           <div class="col-xs-12">
             <h5>SKILLS</h5>
           </div>
-          <div class="col-xs-6 subSection border-right col-left">
+          <div class="col-xs-4 subSection  col-left">
             <ul>
                 <li ng-repeat="skill in career1.skills | orderBy: '-count' | limitTo: 20">
                   {{skill.name}} ({{skill.count}})</li>
             </ul>
           </div>
-          <div class="col-xs-6 subSection border-left col-right">
+          <div class="col-xs-4 subSection col-right">
+            <ul>
+                <li ng-repeat="skill in career2.skills | orderBy: '-count' | limitTo: 20">
+                  {{skill.name}} ({{skill.count}})</li>
+            </ul>
+          </div>
+          <div class="col-xs-4 subSection  col-right">
             <ul>
                 <li ng-repeat="skill in career2.skills | orderBy: '-count' | limitTo: 20">
                   {{skill.name}} ({{skill.count}})</li>
@@ -102,13 +127,22 @@
         <!-- WORK CONTEXT -->
         <div class="row">
           <div class="col-xs-12">
-            <h5>WORK CONTEXT</h5>
+            <h5 class="anchor" id="anchor-context">WORK CONTEXT</h5>
           </div>
-          <div class="col-xs-6 subSection border-right col-left">
-            <ul ng-hide="onetIsNull(career1.onet_titles[0].name)">
-                <li ng-repeat="context in career1.work_context.top_work_contexts" class="longListItem">
+
+          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit1 = 4">
+            <ul>
+              <li ng-repeat="context in career1.work_context.top_work_contexts | limitTo: contextLimit1" class="longListItem">
                 {{context}}</li>
             </ul>
+            <a role="button" class="showMoreCareerInfo" ng-hide="career1.work_context.top_work_contexts.length <= contextLimit1" ng-click="contextLimit1 = career1.work_activities.activities.length">
+              show more
+              <span class="fa fa-chevron-down"></span>
+            </a>
+            <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit1 === career1.work_activities.activities.length" ng-click="contextLimit1 = 4">
+              show less
+              <span class="fa fa-chevron-up"></span>
+            </a>
           </div>
 
           <div class="col-xs-6 border-right noOnetCompare col-left" ng-show="onetIsNull(career1.onet_titles[0].name)">
@@ -120,11 +154,19 @@
             </div>
           </div>
 
-          <div class="col-xs-6 subSection border-left col-right">
-            <ul ng-hide="onetIsNull(career2.onet_titles[0].name)">
-                <li ng-repeat="context in career2.work_context.top_work_contexts" class="longListItem">
+          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit2 = 4">
+            <ul>
+              <li ng-repeat="context in career2.work_context.top_work_contexts | limitTo: contextLimit2" class="longListItem">
                 {{context}}</li>
             </ul>
+            <a role="button" class="showMoreCareerInfo" ng-hide="career2.work_context.top_work_contexts.length <= contextLimit2" ng-click="contextLimit2 = career2.work_activities.activities.length">
+              show more
+              <span class="fa fa-chevron-down"></span>
+            </a>
+            <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit2 === career2.work_activities.activities.length" ng-click="contextLimit2 = 4">
+              show less
+              <span class="fa fa-chevron-up"></span>
+            </a>
           </div>
 
           <div class="col-xs-6 border-left noOnetCompare col-right" ng-show="onetIsNull(career2.onet_titles[0].name)">

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -40,6 +40,7 @@
             <h5 class="anchor" id="anchor-activities">ACTIVITIES</h5>
           </div>
 
+          <!-- Left Column -->
           <div class="col-xs-6 subSection border-right col-left" ng-init="activityLimit = 4">
             <ul>
               <li ng-repeat="activity in career1.work_activities.activities | limitTo: activityLimit" class="longListItem">
@@ -56,6 +57,7 @@
             </a>
           </div>
 
+          <!-- Right Column -->
           <div class="col-xs-6 subSection border-left col-right" ng-init="activityLimit = 4">
             <ul>
               <li ng-repeat="activity in career2.work_activities.activities | limitTo: activityLimit" class="longListItem">
@@ -80,27 +82,30 @@
             <h5>SKILLS</h5>
           </div>
 
-          <div class="col-xs-4 subSection col-left text-center">
-            <p>{{career1.standardized_title}}</p>
+          <!-- Left Column -->
+          <div class="col-xs-4 subSection text-center">
+            <h4>{{career1.standardized_title}}</h4>
             <ul>
-                <li ng-repeat="skill in career1.skills | orderBy: '-count' | limitTo: 20">
-                  {{skill.name}} ({{skill.count}})</li>
+                <li ng-repeat="skill in skills1 | orderBy: '-count' | limitTo: 20">
+                  {{skill}}</li>
             </ul>
           </div>
 
-          <div class="col-xs-4 subSection col-left col-mid text-center" ng-init="intersection = skillIntersection(career1.skills, career2.skills)">
-            <p>Shared Skills</p>
+          <!-- Middle Column -->
+          <div class="col-xs-4 subSection text-center" ng-init="intersection = skillIntersection(career1.skills, career2.skills)">
+            <h4>Both Careers</h4>
             <ul>
-                <li ng-repeat="skill in intersection | orderBy: '-count' | limitTo: 20">
-                  {{skill.name}} ({{skill.count}})</li>
+                <li ng-repeat="skill in skillsIntersect">
+                  {{skill}}</li>
             </ul>
           </div>
 
-          <div class="col-xs-4 subSection col-right text-center">
-            <p>{{career2.standardized_title}}</p>
+          <!-- Right Column -->
+          <div class="col-xs-4 subSection text-center">
+            <h4>{{career2.standardized_title}}</h4>
             <ul>
-                <li ng-repeat="skill in career2.skills | orderBy: '-count' | limitTo: 20">
-                  {{skill.name}} ({{skill.count}})</li>
+                <li ng-repeat="skill in skills2 | orderBy: '-count' | limitTo: 20">
+                  {{skill}}</li>
             </ul>
           </div>
 
@@ -111,6 +116,8 @@
           <div class="col-xs-12">
             <h5>INDUSTRIES</h5>
           </div>
+
+          <!-- Left Column -->
           <div class="col-xs-6 subSection border-right col-left">
             <ul>
                 <li ng-repeat="category in career1.categories | limitTo: 10" >
@@ -120,6 +127,8 @@
                 </li>
             </ul>
           </div>
+
+          <!-- Right Column -->
           <div class="col-xs-6 subSection border-left col-right">
             <ul>
                 <li ng-repeat="category in career2.categories | limitTo: 10" >
@@ -137,7 +146,8 @@
             <h5 class="anchor" id="anchor-context">WORK CONTEXT</h5>
           </div>
 
-          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit = 4">
+          <!-- Left Column -->
+          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit = 4" ng-hide="onetIsNull(career1.onet_titles[0].name)">
             <ul>
               <li ng-repeat="context in career1.work_context.top_work_contexts | limitTo: contextLimit" class="longListItem">
                 {{context}}</li>
@@ -161,7 +171,8 @@
             </div>
           </div>
 
-          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit = 4">
+          <!-- Right Column -->
+          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit = 4" ng-hide="onetIsNull(career2.onet_titles[0].name)">
             <ul>
               <li ng-repeat="context in career2.work_context.top_work_contexts | limitTo: contextLimit" class="longListItem">
                 {{context}}</li>
@@ -193,6 +204,7 @@
             <h5>SALARY</h5>
           </div>
 
+          <!-- Left column -->
           <div class="col-xs-6 subSection border-right col-left">
             <table ng-hide="onetIsNull(career1.onet_titles[0].name)">
               <tr>
@@ -215,6 +227,7 @@
             </div>
           </div>
 
+          <!-- Right Column -->
           <div class="col-xs-6 subSection border-left col-right">
             <table ng-hide="onetIsNull(career2.onet_titles[0].name)">
               <tr>
@@ -245,6 +258,7 @@
             <h5>EDUCATION</h5>
           </div>
 
+          <!-- Left Column -->
           <div class="col-xs-6 subSection border-right col-left">
             <ul ng-hide="onetIsNull(career1.onet_titles[0].name)">
               <li ng-repeat="(degree, percent) in career1.education">
@@ -262,6 +276,7 @@
             </div>
           </div>
 
+          <!-- Right Column -->
           <div class="col-xs-6 subSection border-left col-right">
             <ul ng-hide="onetIsNull(career2.onet_titles[0].name)">
               <li ng-repeat="(degree, percent) in career2.education">

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -172,7 +172,7 @@
           </div>
 
           <!-- Right Column -->
-          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit = 4" ng-hide="onetIsNull(career2.onet_titles[0].name)">
+          <div class="col-xs-6 subSection border-left col-right" ng-init="contextLimit = 4" ng-hide="onetIsNull(career2.onet_titles[0].name)">
             <ul>
               <li ng-repeat="context in career2.work_context.top_work_contexts | limitTo: contextLimit" class="longListItem">
                 {{context}}</li>
@@ -205,8 +205,8 @@
           </div>
 
           <!-- Left column -->
-          <div class="col-xs-6 subSection border-right col-left">
-            <table ng-hide="onetIsNull(career1.onet_titles[0].name)">
+          <div class="col-xs-6 subSection border-right col-left" ng-hide="onetIsNull(career1.onet_titles[0].name)">
+            <table>
               <tr>
                 <td>San Francisco Bay Area</td>
                 <td>{{career1.salary.annual_salary_bay_area | currency}}</td>
@@ -228,8 +228,8 @@
           </div>
 
           <!-- Right Column -->
-          <div class="col-xs-6 subSection border-left col-right">
-            <table ng-hide="onetIsNull(career2.onet_titles[0].name)">
+          <div class="col-xs-6 subSection border-left col-right" ng-hide="onetIsNull(career2.onet_titles[0].name)">
+            <table>
               <tr>
                 <td>San Francisco Bay Area</td>
                 <td>{{career2.salary.annual_salary_bay_area | currency}}</td>
@@ -259,8 +259,8 @@
           </div>
 
           <!-- Left Column -->
-          <div class="col-xs-6 subSection border-right col-left">
-            <ul ng-hide="onetIsNull(career1.onet_titles[0].name)">
+          <div class="col-xs-6 subSection border-right col-left" ng-hide="onetIsNull(career1.onet_titles[0].name)">
+            <ul>
               <li ng-repeat="(degree, percent) in career1.education">
                 {{degree}} {{percent}}%
               </li>
@@ -277,8 +277,8 @@
           </div>
 
           <!-- Right Column -->
-          <div class="col-xs-6 subSection border-left col-right">
-            <ul ng-hide="onetIsNull(career2.onet_titles[0].name)">
+          <div class="col-xs-6 subSection border-left col-right" ng-hide="onetIsNull(career2.onet_titles[0].name)">
+            <ul>
               <li ng-repeat="(degree, percent) in career2.education">
                 {{degree}} {{percent}}%
               </li>

--- a/client/templates/results.ng.html
+++ b/client/templates/results.ng.html
@@ -79,19 +79,9 @@
 
         <div class="resultBox">
           <h5 class="text-capitalize">
-            <a ui-sref="careerView({careerId: career._id})" ng-click="viewCareer(career.standardized_title, career._id)">{{career.standardized_title}} ({{career.num_ids}})</a>
+            <a ui-sref="careerView({careerId: career._id})" ng-click="viewCareer(career.standardized_title, career._id)">{{career.standardized_title}}</a>
             <span class="fa fa-thumb-tack pin colorTransFast" aria-label="pin this career" ng-class="{pinSelected: isPinned(career._id)}" ng-click="togglePinnedCareer(career.standardized_title, career._id)"></span>
           </h5>
-<!-- 
-          <div class="row col-xs-12">
-            <h6>TOP ACTIVITIES</h6>
-            <ul class="fa-ul">
-              <li ng-repeat="activity in career.work_activities | limitTo: 3" class="longListItem">
-                <span class="fa fa-li fa-angle-right fa-lg"></span>
-                {{activity}}
-              </li>
-            </ul>
-          </div> -->
 
           <div class="row">
 

--- a/client/templates/sidebar.ng.html
+++ b/client/templates/sidebar.ng.html
@@ -60,7 +60,7 @@
 
         <div ng-hide="pinnedCareers.length == 0">
 
-          <span class="text-muted small">select 2 careers to compare</span>
+          <span class="text-center small">select 2 pinned careers to compare</span>
 
           <ul class="sidebarList pinnedList">
             <li ng-repeat="p in pinnedCareers track by p.id" class="text-capitalize">

--- a/client/templates/view-career.ng.html
+++ b/client/templates/view-career.ng.html
@@ -199,20 +199,28 @@
         
           <h3 class="col-xs-12 sectionTitle">Related Careers</h3>
 
-          <div class="col-xs-4 subSection">
+<!--           <div class="col-xs-4 subSection">
             <ul>
-              <li ng-repeat= "rel in career.related_careers" class="longListItem">
+              <li ng-repeat= "rel in career.related_careers.slice" class="longListItem">
                 <a ui-sref="careerView({careerId: lookupIdByName(rel)})" ng-click="viewCareer(rel, lookupIdByName(rel))">
                   {{rel}}</a></li>
             </ul>
+          </div> -->
+
+          <div class="col-xs-4 subSection">
+              <a ui-sref="careerView({careerId: lookupIdByName(rel)})" ng-click="viewCareer(rel, lookupIdByName(rel))">
+                  {{career.related_careers[0]}}</a>
           </div>
 
-          <!-- <div class="col-xs-4 subSection">
-            <ul>
-              <li class="longListItem"><a href="">Search Marketing Strategist</a></li>
-              <li class="longListItem"><a href="">Software Quality Assurance Engineer</a></li>
-            </ul>
-          </div> -->
+          <div class="col-xs-4 subSection">
+              <a ui-sref="careerView({careerId: lookupIdByName(rel)})" ng-click="viewCareer(rel, lookupIdByName(rel))">
+                  {{career.related_careers[1]}}</a>
+          </div>
+
+          <div class="col-xs-4 subSection">
+              <a ui-sref="careerView({careerId: lookupIdByName(rel)})" ng-click="viewCareer(rel, lookupIdByName(rel))">
+                  {{career.related_careers[2]}}</a>
+          </div>
 
           <div class="col-xs-12 hr"></div>
 
@@ -226,17 +234,20 @@
 
           <div class="row col-xs-12">
 
-            <div class="col-xs-7 subSection">
+            <div class="col-xs-12">
               <h5>SAMPLE JOB TITLES</h5>
               <p>Click below to search Glassdoor.com for jobs.</p>
-              <ul>
-                <li ng-repeat="title in career.job_titles | orderBy: '-count' | limitTo: 8">
-                  <a href="http://www.glassdoor.com/Job/{{ createUrlString(title.name, true) }}-jobs-SRCH_KO0,{{title.name.length}}.htm" target="_blank">
-                  {{title.name}}
-                  </a>
-                </li>
-              </ul>
             </div>
+
+            <ul>
+              <li class="col-xs-4" ng-repeat="title in career.job_titles | orderBy: '-count' | limitTo: 9">
+                <a href="http://www.glassdoor.com/Job/{{ createUrlString(title.name, true) }}-jobs-SRCH_KO0,{{title.name.length}}.htm" target="_blank">
+                {{title.name}}
+                </a>
+              </li>
+            </ul>
+            
+            <div class="col-xs-12 subSection"></div>
 
             <!-- <div class="col-xs-offset-1 col-xs-4 featuredLinkBox">
               <h5>Meet Cool People</h5>
@@ -248,32 +259,32 @@
               </span>
             </div> -->
           
-            <div class="subSection">
+            <div>
 
-              <div class="col-xs-7">
+              <div class="col-xs-12">
                 <h5>RESUME KEYWORDS</h5>
                 <p>Use these top words drawn from <strong>{{career.job_ids.length}}</strong> 
                 {{career.standardized_title}} job postings when updating your resume.</p>
               </div>
 
-              <div class="col-xs-12"></div>
+              <!-- <div class="col-xs-12"></div> -->
 
-              <div class="col-xs-3">
-                <h5>Verbs</h5>
+              <div class="col-xs-4 subSection">
+                <h4>Verbs</h4>
                 <ul>
                   <li ng-repeat="verb in career.work_activities.top_verbs">{{verb}}</li>
                 </ul>
               </div>
               
-              <div class="col-xs-3">
-                <h5>Nouns</h5>
+              <div class="col-xs-4 subSection">
+                <h4>Nouns</h4>
                   <ul>
                     <li ng-repeat="noun in career.work_activities.top_nouns">{{noun}}</li>
                   </ul>
               </div>
               
-              <div class="col-xs-3">
-                <h5>Adjectives</h5>
+              <div class="col-xs-4 subSection">
+                <h4>Adjectives</h4>
                 <ul>
                   <li ng-repeat="adjective in career.work_activities.top_adjs">{{adjective}}</li>
                 </ul>

--- a/client/templates/view-career.ng.html
+++ b/client/templates/view-career.ng.html
@@ -53,7 +53,7 @@
             <ul>
               <li ng-repeat="skill in career.skills | orderBy: '-count' | limitTo: skillLimit">
                 <a ng-click="setQuery(skill.name)" aria-label="search for {{skill.name}}" ui-sref="results({queryString: queryStringURL})">
-                {{skill.name}} ({{skill.count}})
+                {{skill.name}}
               </a>
               </li>
             </ul>
@@ -81,7 +81,7 @@
             <ul>
               <li ng-repeat="category in career.categories | limitTo: 10" >
                 <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
-                  {{category.name}} {{category.count}}
+                  {{category.name}}
                 </a>
               </li>
             </ul>
@@ -211,7 +211,8 @@
 
               <div class="col-xs-7">
                 <h5>RESUME KEYWORDS</h5>
-                <p>Use these top words from {{career.job_ids.length}} {{career.standardized_title}} job postings when updating your resume.</p>
+                <p>Use these top words drawn from <strong>{{career.job_ids.length}}</strong> 
+                {{career.standardized_title}} job postings when updating your resume.</p>
               </div>
 
               <div class="col-xs-12"></div>

--- a/client/templates/view-career.ng.html
+++ b/client/templates/view-career.ng.html
@@ -202,8 +202,8 @@
           <div class="col-xs-4 subSection">
             <ul>
               <li ng-repeat= "rel in career.related_careers" class="longListItem">
-                <!-- <a ui-sref="careerView({careerId: lookupIdByName(rel)})" ng-click="viewCareer(rel, lookupIdByName(rel))"> -->
-                  <a>{{rel}}</a></li>
+                <a ui-sref="careerView({careerId: lookupIdByName(rel)})" ng-click="viewCareer(rel, lookupIdByName(rel))">
+                  {{rel}}</a></li>
             </ul>
           </div>
 

--- a/style/style.less
+++ b/style/style.less
@@ -516,6 +516,10 @@ li .xRemove:hover {
   padding: @padding-base-vertical*4 0px;
 }
 
+.compare .row {
+  margin-left: 0px;
+}
+
 .compare .col-right {
   padding: @padding-base-vertical*2 @padding-base-horizontal*6 @padding-base-vertical*8 @padding-base-horizontal*4;
 }
@@ -530,14 +534,6 @@ li .xRemove:hover {
 
 .noOnetCompare {
   font-size: @font-size-small;
-}
-
-.noOnetCompare.col-left {
-  margin-left: -428px; 
-}
-
-.noOnetCompare.col-right {
-  margin-top: -60px;
 }
 
 .noOnetCompare div {

--- a/style/style.less
+++ b/style/style.less
@@ -449,6 +449,10 @@ li .xRemove:hover {
 
 // View Career
 
+.profile h5, .compare h5 {
+  color: @brand-secondary;
+}
+
 .sectionTitle {
   padding-top: @padding-base-vertical;
   padding-bottom: @padding-base-vertical;
@@ -501,10 +505,6 @@ li .xRemove:hover {
 
 .subSection {
   padding-bottom: @padding-base-vertical*8;
-}
-
-.subSection h5 {
-  color: @brand-secondary;
 }
 
 .subSection .longListItem {

--- a/style/style.less
+++ b/style/style.less
@@ -524,6 +524,10 @@ li .xRemove:hover {
   padding: @padding-base-vertical*2 @padding-base-horizontal*4 @padding-base-vertical*8 @padding-base-horizontal*6;
 }
 
+.compare .col-mid {
+  padding: @padding-base-vertical*2 @padding-base-horizontal*4;
+}
+
 .noOnetCompare {
   font-size: @font-size-small;
 }


### PR DESCRIPTION
Compare Careers
- show more / show less for work activities and work context
- sync show more/less between both columns
- column margin and padding fixes
- get intersection of skills for compare view
- print intersection list and unique skill lists

Sidebar
- edit style and text of instruction message for comparing careers

Career View
- merge related career links into template
- 3-column layout for related careers and get hired section

Misc.
- remove unnecessary counts from results view, career view, and compare view
- merge chart updates
- change bar chart colors to match color palette
- fix function for creating url string for glassdoor link
  *\* bug remains when trying to use this function for class-central link or meetup link
