### PR TITLE
ui - misc. ui updates from usability tests

### DIFF
--- a/client/controllers.js
+++ b/client/controllers.js
@@ -589,15 +589,10 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
             $scope.industries1 = _.pluck(_.sortBy($scope.career1.categories, -'count').slice(0,10), 'name');
             $scope.industries2 = _.pluck(_.sortBy($scope.career2.categories, -'count').slice(0,10), 'name');
 
-            console.log($scope.industries1);
-
             // get intersecting and unique industries
-            $scope.industriesIntersect = _.intersection($scope.industries1, $scope.industries1);
-
-            console.log($scope.industriesIntersect);
-            
+            $scope.industriesIntersect = _.intersection($scope.industries1, $scope.industries2);
             $scope.industries1 = _.xor($scope.industries1, $scope.industriesIntersect);
-            $scope.industries1 = _.xor($scope.industries2, $scope.skillsInindustriesIntersecttersect);
+            $scope.industries2 = _.xor($scope.industries2, $scope.industriesIntersect);
 
         });
 

--- a/client/controllers.js
+++ b/client/controllers.js
@@ -580,6 +580,8 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
             $scope.career1.education = newEdArray1;
             $scope.career2.education = newEdArray2;
 
+
+            // *** Skill Intersection for Compare View
             // get top 20 skills for each career
             $scope.skills1 = _.pluck(_.sortBy($scope.career1.skills, -'count').slice(0,20), 'name');
             $scope.skills2 = _.pluck(_.sortBy($scope.career2.skills, -'count').slice(0,20), 'name');
@@ -590,6 +592,7 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
             $scope.skills2 = _.xor($scope.skills2, $scope.skillsIntersect);
 
 
+            // *** Category Intersection for Compare View
             // get top 10 categories for each career
             $scope.categories1 = _.pluck(_.sortBy($scope.career1.categories, -'count').slice(0,10), 'name');
             $scope.categories2 = _.pluck(_.sortBy($scope.career2.categories, -'count').slice(0,10), 'name');
@@ -598,6 +601,19 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
             $scope.categoriesIntersect = _.intersection($scope.categories1, $scope.categories2);
             $scope.categories1 = _.xor($scope.categories1, $scope.categoriesIntersect);
             $scope.categories2 = _.xor($scope.categories2, $scope.categoriesIntersect);
+
+            // *** Work Context Intersection for Compare View
+            // get work contexts for each career
+            $scope.contexts1 = $scope.career1.work_context.top_work_contexts;
+            $scope.contexts2 = $scope.career2.work_context.top_work_contexts;
+
+            // get intersecting and unique contexts
+            $scope.contextIntersect = _.intersection($scope.contexts1, $scope.contexts2);
+            $scope.contexts1 = _.xor($scope.contexts1, $scope.contextIntersect);
+            $scope.contexts2 = _.xor($scope.contexts2, $scope.contextIntersect);
+            console.log($scope.contextIntersect);
+            console.log($scope.contexts1);
+            console.log($scope.contexts2);
 
         });
 

--- a/client/controllers.js
+++ b/client/controllers.js
@@ -19,7 +19,7 @@ angular.module('reflectivePath').controller('NavBarController', ['$scope',
     // JSON.parse to read the stack in as an array
     $scope.queryStack = JSON.parse($window.localStorage.getItem('queryStack'));
 
-    // needed for querying by clicking on industry or skill
+    // needed for querying by clicking on category or skill
     $scope.setQuery = function(input) {
         //set query
         $scope.query = input;
@@ -96,7 +96,7 @@ angular.module('reflectivePath').controller('HomeSearchController', ['$scope', '
 
     $scope.topCareers = ['Software Engineer', 'Medical Manager', 'Sales Representative', 'Product Manager', 'User Experience Designer', 'Data Scientist'];
     $scope.topSkills = ['communication', 'programming', 'design', 'customer service', 'marketing', 'analytics'];
-    $scope.topIndustries = ['Information Technology', 'Consulting', 'Health Care', 'Design', 'Nonprofit', 'Sales'];
+    $scope.topCategories = ['Information Technology', 'Consulting', 'Health Care', 'Design', 'Nonprofit', 'Sales'];
 
 
 }]);
@@ -156,7 +156,7 @@ angular.module('reflectivePath').controller('ResultsController', ['$scope',
     // JSON.parse to read the stack in as an array
     $scope.queryStack = JSON.parse($window.localStorage.getItem('queryStack'));
 
-    // needed for querying by clicking on industry or skill
+    // needed for querying by clicking on category or skill
     $scope.setQuery = function(input) {
         //set query
         $scope.query = input;
@@ -366,7 +366,7 @@ function($scope, $meteor, $stateParams, $state, $window, $rootScope, $location, 
     // JSON.parse to read the stack in as an array
     $scope.queryStack = JSON.parse($window.localStorage.getItem('queryStack'));
 
-    // needed for querying by clicking on industry or skill
+    // needed for querying by clicking on category or skill
     $scope.setQuery = function(input) {
         //set query
         $scope.query = input;
@@ -572,9 +572,6 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
             $scope.career1.education = newEdArray1;
             $scope.career2.education = newEdArray2;
 
-            console.log($scope.career1);
-
-
             // get top 20 skills for each career
             $scope.skills1 = _.pluck(_.sortBy($scope.career1.skills, -'count').slice(0,20), 'name');
             $scope.skills2 = _.pluck(_.sortBy($scope.career2.skills, -'count').slice(0,20), 'name');
@@ -585,14 +582,14 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
             $scope.skills2 = _.xor($scope.skills2, $scope.skillsIntersect);
 
 
-            // get top 10 industries for each career
-            $scope.industries1 = _.pluck(_.sortBy($scope.career1.categories, -'count').slice(0,10), 'name');
-            $scope.industries2 = _.pluck(_.sortBy($scope.career2.categories, -'count').slice(0,10), 'name');
+            // get top 10 categories for each career
+            $scope.categories1 = _.pluck(_.sortBy($scope.career1.categories, -'count').slice(0,10), 'name');
+            $scope.categories2 = _.pluck(_.sortBy($scope.career2.categories, -'count').slice(0,10), 'name');
 
-            // get intersecting and unique industries
-            $scope.industriesIntersect = _.intersection($scope.industries1, $scope.industries2);
-            $scope.industries1 = _.xor($scope.industries1, $scope.industriesIntersect);
-            $scope.industries2 = _.xor($scope.industries2, $scope.industriesIntersect);
+            // get intersecting and unique categories
+            $scope.categoriesIntersect = _.intersection($scope.categories1, $scope.categories2);
+            $scope.categories1 = _.xor($scope.categories1, $scope.categoriesIntersect);
+            $scope.categories2 = _.xor($scope.categories2, $scope.categoriesIntersect);
 
         });
 
@@ -608,7 +605,7 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
     // JSON.parse to read the stack in as an array
     $scope.queryStack = JSON.parse($window.localStorage.getItem('queryStack'));
 
-    // needed for querying by clicking on industry or skill
+    // needed for querying by clicking on category or skill
     $scope.setQuery = function(input) {
         //set query
         $scope.query = input;

--- a/client/controllers.js
+++ b/client/controllers.js
@@ -196,6 +196,10 @@ angular.module('reflectivePath').controller('ResultsController', ['$scope',
         if (_.contains(_.pluck($scope.pinnedCareers, 'id'), careerId)) {
             // remove id from pinned list
             $scope.pinnedCareers = _.without($scope.pinnedCareers, _.findWhere($scope.pinnedCareers, {id: careerId}));
+            // and remove from compared list if it's there
+            if (_.contains($scope.comparedCareers, careerId)) {
+                $scope.comparedCareers = _.without($scope.comparedCareers, careerId);
+            }
         } else {
             // else add to pinnedCareers
             $scope.pinnedCareers.push(pinnedCareer);
@@ -406,6 +410,10 @@ function($scope, $meteor, $stateParams, $state, $window, $rootScope, $location, 
         if (_.contains(_.pluck($scope.pinnedCareers, 'id'), careerId)) {
             // remove id from pinned list
             $scope.pinnedCareers = _.without($scope.pinnedCareers, _.findWhere($scope.pinnedCareers, {id: careerId}));
+            // and remove from compared list if it's there
+            if (_.contains($scope.comparedCareers, careerId)) {
+                $scope.comparedCareers = _.without($scope.comparedCareers, careerId);
+            }
         } else {
             // else add to pinnedCareers
             $scope.pinnedCareers.push(pinnedCareer);
@@ -644,6 +652,10 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
         if (_.contains(_.pluck($scope.pinnedCareers, 'id'), careerId)) {
             // remove id from pinned list
             $scope.pinnedCareers = _.without($scope.pinnedCareers, _.findWhere($scope.pinnedCareers, {id: careerId}));
+            // and remove from compared list if it's there
+            if (_.contains($scope.comparedCareers, careerId)) {
+                $scope.comparedCareers = _.without($scope.comparedCareers, careerId);
+            }
         } else {
             // else add to pinnedCareers
             $scope.pinnedCareers.push(pinnedCareer);

--- a/client/controllers.js
+++ b/client/controllers.js
@@ -584,6 +584,21 @@ function($scope, $meteor, $stateParams, $window, $rootScope, $location, $anchorS
             $scope.skills1 = _.xor($scope.skills1, $scope.skillsIntersect);
             $scope.skills2 = _.xor($scope.skills2, $scope.skillsIntersect);
 
+
+            // get top 10 industries for each career
+            $scope.industries1 = _.pluck(_.sortBy($scope.career1.categories, -'count').slice(0,10), 'name');
+            $scope.industries2 = _.pluck(_.sortBy($scope.career2.categories, -'count').slice(0,10), 'name');
+
+            console.log($scope.industries1);
+
+            // get intersecting and unique industries
+            $scope.industriesIntersect = _.intersection($scope.industries1, $scope.industries1);
+
+            console.log($scope.industriesIntersect);
+            
+            $scope.industries1 = _.xor($scope.industries1, $scope.industriesIntersect);
+            $scope.industries1 = _.xor($scope.industries2, $scope.skillsInindustriesIntersecttersect);
+
         });
 
     });

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -122,7 +122,7 @@
             <h4>{{career1.standardized_title}}</h4>
             <ul>
                 <li ng-repeat="industry in industries1">
-                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
+                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: industry})">
                     {{industry}}
                   </a>   
                 </li>
@@ -134,7 +134,7 @@
             <h4>Both Careers</h4>
             <ul>
                 <li ng-repeat="industry in industriesIntersect">
-                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
+                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: industry})">
                     {{industry}}
                   </a>   
                 </li>
@@ -151,7 +151,7 @@
             <h4>{{career2.standardized_title}}</h4>
             <ul>
                 <li ng-repeat="industry in industries2">
-                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
+                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: industry})">
                     {{industry}}
                   </a>   
                 </li>

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -41,7 +41,7 @@
           </div>
 
           <!-- Left Column -->
-          <div class="col-xs-6 subSection border-right col-left" ng-init="activityLimit = 4">
+          <div class="col-xs-6 subSection border-right col-left" ng-init="activityLimit = 3">
             <ul>
               <li ng-repeat="activity in career1.work_activities.activities | limitTo: activityLimit" class="longListItem">
                 {{activity}}
@@ -51,14 +51,14 @@
               show all activities
               <span class="fa fa-chevron-down"></span>
             </a>
-            <a href="#anchor-activities" role="button" class="showMoreCareerInfo" ng-show="activityLimit == 30" ng-click="activityLimit = 4">
+            <a href="#anchor-activities" role="button" class="showMoreCareerInfo" ng-show="activityLimit == 30" ng-click="activityLimit = 3">
               show fewer activities
               <span class="fa fa-chevron-up"></span>
             </a>
           </div>
 
           <!-- Right Column -->
-          <div class="col-xs-6 subSection border-left col-right" ng-init="activityLimit = 4">
+          <div class="col-xs-6 subSection border-left col-right" ng-init="activityLimit = 3">
             <ul>
               <li ng-repeat="activity in career2.work_activities.activities | limitTo: activityLimit" class="longListItem">
                 {{activity}}
@@ -68,7 +68,7 @@
               show all activities
               <span class="fa fa-chevron-down"></span>
             </a>  
-            <a href="#anchor-activities" role="button" class="showMoreCareerInfo" ng-show="activityLimit == 30" ng-click="activityLimit = 4">
+            <a href="#anchor-activities" role="button" class="showMoreCareerInfo" ng-show="activityLimit == 30" ng-click="activityLimit = 3">
               show fewer activities
               <span class="fa fa-chevron-up"></span>
             </a>

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -138,6 +138,11 @@
                     {{industry}}
                   </a>   
                 </li>
+                <li class="noOnetCompare" ng-if="industriesIntersect == 0">
+                  <div>
+                    The job postings aggregated for these careers did not share any industries
+                  </div>
+                </li>
             </ul>
           </div>
 

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -185,10 +185,10 @@
 
           <div class="col-xs-6 border-right noOnetCompare col-left" ng-show="onetIsNull(career1.onet_titles[0].name)">
             <div>
-              <h5>No Data</h5>
-              <p>Sorry, we don't have this data for 
-                <strong>{{career1.standardized_title}}</strong>.</p>
-              <p><a href="">Read more about our data sources</a>.</p>
+              <h5>Sorry, we don't have this data</h5>
+              <p>We get this kind of data from the government's
+                <a href="http://www.onetonline.org/" target="_blank">O*Net Online</a> resource. 
+                Unfortunately, the government isn't collecting data for <strong>{{career1.standardized_title}}</strong>.</p>
             </div>
           </div>
 
@@ -210,10 +210,10 @@
 
           <div class="col-xs-6 border-left noOnetCompare col-right" ng-show="onetIsNull(career2.onet_titles[0].name)">
             <div>
-              <h5>No Data</h5>
-              <p>Sorry, we don't have this data for 
-                <strong>{{career2.standardized_title}}</strong>.</p>
-              <p><a href="">Read more about our data sources</a>.</p>
+              <h5>Sorry, we don't have this data</h5>
+              <p>We get this kind of data from the government's
+                <a href="http://www.onetonline.org/" target="_blank">O*Net Online</a> resource. 
+                Unfortunately, the government isn't collecting data for <strong>{{career2.standardized_title}}</strong>.</p>
             </div>
           </div>
 
@@ -253,10 +253,10 @@
 
           <div class="col-xs-6 border-right noOnetCompare col-left" ng-show="onetIsNull(career1.onet_titles[0].name)">
             <div>
-              <h5>No Data</h5>
-              <p>Sorry, we don't have this data for 
-                <strong>{{career1.standardized_title}}</strong>.</p>
-              <p><a href="">Read more about our data sources</a>.</p>
+              <h5>Sorry, we don't have this data</h5>
+              <p>We get this kind of data from the government's
+                <a href="http://www.onetonline.org/" target="_blank">O*Net Online</a> resource. 
+                Unfortunately, the government isn't collecting data for <strong>{{career1.standardized_title}}</strong>.</p>
             </div>
           </div>
 
@@ -287,10 +287,10 @@
 
           <div class="col-xs-6 border-left noOnetCompare col-right" ng-show="onetIsNull(career2.onet_titles[0].name)">
             <div>
-              <h5>No Data</h5>
-              <p>Sorry, we don't have this data for 
-                <strong>{{career2.standardized_title}}</strong>.</p>
-              <p><a href="">Read more about our data sources</a>.</p>
+              <h5>Sorry, we don't have this data</h5>
+              <p>We get this kind of data from the government's
+                <a href="http://www.onetonline.org/" target="_blank">O*Net Online</a> resource. 
+                Unfortunately, the government isn't collecting data for <strong>{{career2.standardized_title}}</strong>.</p>
             </div>
           </div>
 
@@ -323,10 +323,10 @@
 
           <div class="col-xs-6 border-right noOnetCompare col-left" ng-show="onetIsNull(career1.onet_titles[0].name)">
             <div>
-              <h5>No Data</h5>
-              <p>Sorry, we don't have this data for 
-                <strong>{{career1.standardized_title}}</strong>.</p>
-              <p><a href="">Read more about our data sources</a>.</p>
+              <h5>Sorry, we don't have this data</h5>
+              <p>We get this kind of data from the government's
+                <a href="http://www.onetonline.org/" target="_blank">O*Net Online</a> resource. 
+                Unfortunately, the government isn't collecting data for <strong>{{career1.standardized_title}}</strong>.</p>
             </div>
           </div>
 
@@ -351,10 +351,10 @@
 
           <div class="col-xs-6 border-left noOnetCompare col-right" ng-show="onetIsNull(career2.onet_titles[0].name)">
             <div>
-              <h5>No Data</h5>
-              <p>Sorry, we don't have this data for 
-                <strong>{{career2.standardized_title}}</strong>.</p>
-              <p><a href="">Read more about our data sources</a>.</p>
+              <h5>Sorry, we don't have this data</h5>
+              <p>We get this kind of data from the government's
+                <a href="http://www.onetonline.org/" target="_blank">O*Net Online</a> resource. 
+                Unfortunately, the government isn't collecting data for <strong>{{career2.standardized_title}}</strong>.</p>
             </div>
           </div>
 

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -111,19 +111,19 @@
 
         </div>
 
-        <!-- INDUSTRIES -->
+        <!-- CATEGORIES -->
         <div class="row">
           <div class="col-xs-12">
-            <h5>INDUSTRIES</h5>
+            <h5>CATEGORIES</h5>
           </div>
 
           <!-- Left Column -->
           <div class="col-xs-4 subSection text-center">
             <h4>{{career1.standardized_title}}</h4>
             <ul>
-                <li ng-repeat="industry in industries1">
-                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: industry})">
-                    {{industry}}
+                <li ng-repeat="category in categories1">
+                  <a class="categoryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: category})">
+                    {{category}}
                   </a>   
                 </li>
             </ul>
@@ -133,14 +133,14 @@
           <div class="col-xs-4 subSection text-center" ng-init="intersection = skillIntersection(career1.skills, career2.skills)">
             <h4>Both Careers</h4>
             <ul>
-                <li ng-repeat="industry in industriesIntersect">
-                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: industry})">
-                    {{industry}}
+                <li ng-repeat="category in categoriesIntersect">
+                  <a class="categoryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: category})">
+                    {{category}}
                   </a>   
                 </li>
-                <li class="noOnetCompare" ng-if="industriesIntersect == 0">
+                <li class="noOnetCompare" ng-if="categoriesIntersect == 0">
                   <div>
-                    The job postings aggregated for these careers did not share any industries
+                    The job postings aggregated for these careers did not share any categories
                   </div>
                 </li>
             </ul>
@@ -150,9 +150,9 @@
           <div class="col-xs-4 subSection text-center">
             <h4>{{career2.standardized_title}}</h4>
             <ul>
-                <li ng-repeat="industry in industries2">
-                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: industry})">
-                    {{industry}}
+                <li ng-repeat="category in categories2">
+                  <a class="categoryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: category})">
+                    {{category}}
                   </a>   
                 </li>
             </ul>

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -161,63 +161,109 @@
 
         </div>
 
+
         <!-- WORK CONTEXT -->
         <div class="row">
           <div class="col-xs-12">
             <h5 class="anchor" id="anchor-context">WORK CONTEXT</h5>
           </div>
 
-          <!-- Left Column -->
-          <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit = 4" ng-hide="onetIsNull(career1.onet_titles[0].name)">
-            <ul>
-              <li ng-repeat="context in career1.work_context.top_work_contexts | limitTo: contextLimit" class="longListItem">
-                {{context}}</li>
-            </ul>
-            <a role="button" class="showMoreCareerInfo" ng-hide="career1.work_context.top_work_contexts.length <= contextLimit" ng-click="contextLimit = 20">
-              show more
-              <span class="fa fa-chevron-down"></span>
-            </a>
-            <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit == 20" ng-click="contextLimit = 4">
-              show less
-              <span class="fa fa-chevron-up"></span>
-            </a>
-          </div>
+          <!-- Begin Work Context Section with Intersect -->
+          <div ng-hide="onetIsNull(career1.onet_titles[0].name) || onetIsNull(career2.onet_titles[0].name)">
 
-          <div class="col-xs-6 border-right noOnetCompare col-left" ng-show="onetIsNull(career1.onet_titles[0].name)">
-            <div>
-              <h5>Sorry, we don't have this data</h5>
-              <p>We get this kind of data from the government's
-                <a href="http://www.onetonline.org/" target="_blank">O*Net Online</a> resource. 
-                Unfortunately, the government isn't collecting data for <strong>{{career1.standardized_title}}</strong>.</p>
+            <!-- Left Column -->
+            <div class="col-xs-4 subSection text-center">
+              <h4>{{career1.standardized_title}}</h4>
+              <ul>
+                  <li ng-repeat="context in contexts1" class="longListItem">
+                    {{context}}  
+                  </li>
+              </ul>
             </div>
-          </div>
 
-          <!-- Right Column -->
-          <div class="col-xs-6 subSection border-left col-right" ng-init="contextLimit = 4" ng-hide="onetIsNull(career2.onet_titles[0].name)">
-            <ul>
-              <li ng-repeat="context in career2.work_context.top_work_contexts | limitTo: contextLimit" class="longListItem">
-                {{context}}</li>
-            </ul>
-            <a role="button" class="showMoreCareerInfo" ng-hide="career2.work_context.top_work_contexts.length <= contextLimit" ng-click="contextLimit = 20">
-              show more
-              <span class="fa fa-chevron-down"></span>
-            </a>
-            <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit == 20" ng-click="contextLimit = 4">
-              show less
-              <span class="fa fa-chevron-up"></span>
-            </a>
-          </div>
-
-          <div class="col-xs-6 border-left noOnetCompare col-right" ng-show="onetIsNull(career2.onet_titles[0].name)">
-            <div>
-              <h5>Sorry, we don't have this data</h5>
-              <p>We get this kind of data from the government's
-                <a href="http://www.onetonline.org/" target="_blank">O*Net Online</a> resource. 
-                Unfortunately, the government isn't collecting data for <strong>{{career2.standardized_title}}</strong>.</p>
+            <!-- Middle Column -->
+            <div class="col-xs-4 subSection text-center" ng-init="intersection = skillIntersection(career1.skills, career2.skills)">
+              <h4>Both Careers</h4>
+              <ul>
+                  <li ng-repeat="context in contextIntersect" class="longListItem">
+                    {{context}}  
+                  </li>
+                  <li class="noOnetCompare" ng-if="categoriesIntersect == 0">
+                    <div>
+                      These careers did not share any work context descriptions in our data
+                    </div>
+                  </li>
+              </ul>
             </div>
-          </div>
 
-        </div>
+            <!-- Right Column -->
+            <div class="col-xs-4 subSection text-center">
+              <h4>{{career2.standardized_title}}</h4>
+              <ul>
+                  <li ng-repeat="context in contexts2" class="longListItem">
+                    {{context}}  
+                  </li>
+              </ul>
+            </div>
+
+          </div> <!-- End Work Context Section with Intersect -->
+
+          <!-- Begin Work Context Section when some O*Net data is Missing -->
+          <div ng-show="onetIsNull(career1.onet_titles[0].name) || onetIsNull(career2.onet_titles[0].name)">
+
+            <!-- Left Column -->
+            <div class="col-xs-6 subSection border-right col-left" ng-init="contextLimit = 4" ng-hide="onetIsNull(career1.onet_titles[0].name)">
+              <ul>
+                <li ng-repeat="context in career1.work_context.top_work_contexts | limitTo: contextLimit" class="longListItem">
+                  {{context}}</li>
+              </ul>
+              <a role="button" class="showMoreCareerInfo" ng-hide="career1.work_context.top_work_contexts.length <= contextLimit" ng-click="contextLimit = 20">
+                show more
+                <span class="fa fa-chevron-down"></span>
+              </a>
+              <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit == 20" ng-click="contextLimit = 4">
+                show less
+                <span class="fa fa-chevron-up"></span>
+              </a>
+            </div>
+
+            <div class="col-xs-6 border-right noOnetCompare col-left" ng-show="onetIsNull(career1.onet_titles[0].name)">
+              <div>
+                <h5>Sorry, we don't have this data</h5>
+                <p>We get this kind of data from the government's
+                  <a href="http://www.onetonline.org/" target="_blank">O*Net Online</a> resource. 
+                  Unfortunately, the government isn't collecting data for <strong>{{career1.standardized_title}}</strong>.</p>
+              </div>
+            </div>
+
+            <!-- Right Column -->
+            <div class="col-xs-6 subSection border-left col-right" ng-init="contextLimit = 4" ng-hide="onetIsNull(career2.onet_titles[0].name)">
+              <ul>
+                <li ng-repeat="context in career2.work_context.top_work_contexts | limitTo: contextLimit" class="longListItem">
+                  {{context}}</li>
+              </ul>
+              <a role="button" class="showMoreCareerInfo" ng-hide="career2.work_context.top_work_contexts.length <= contextLimit" ng-click="contextLimit = 20">
+                show more
+                <span class="fa fa-chevron-down"></span>
+              </a>
+              <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit == 20" ng-click="contextLimit = 4">
+                show less
+                <span class="fa fa-chevron-up"></span>
+              </a>
+            </div>
+
+            <div class="col-xs-6 border-left noOnetCompare col-right" ng-show="onetIsNull(career2.onet_titles[0].name)">
+              <div>
+                <h5>Sorry, we don't have this data</h5>
+                <p>We get this kind of data from the government's
+                  <a href="http://www.onetonline.org/" target="_blank">O*Net Online</a> resource. 
+                  Unfortunately, the government isn't collecting data for <strong>{{career2.standardized_title}}</strong>.</p>
+              </div>
+            </div>
+
+          </div>  <!-- End Work Context Section when some O*Net data is Missing -->
+
+        </div> <!-- End Work Context Section -->
 
         <!-- SALARY -->
         <div class="row">
@@ -294,7 +340,7 @@
             </div>
           </div>
 
-        </div>
+        </div>  <!-- End Salary Section -->
 
         <!-- EDUCATION -->
         <div class="row">
@@ -358,13 +404,13 @@
             </div>
           </div>
 
-        </div>
+        </div>  <!-- End Education Section -->
 
         
-      </div>
+      </div>  <!-- End Card Section -->
      
-    </div>
+    </div>  <!-- End Compare Section -->
 
-  </div> 
+  </div>  <!-- End Main Section -->
 
-</div>
+</div>  <!-- End Container -->

--- a/client/templates/compare-careers.ng.html
+++ b/client/templates/compare-careers.ng.html
@@ -86,7 +86,7 @@
           <div class="col-xs-4 subSection text-center">
             <h4>{{career1.standardized_title}}</h4>
             <ul>
-                <li ng-repeat="skill in skills1 | orderBy: '-count' | limitTo: 20">
+                <li ng-repeat="skill in skills1">
                   {{skill}}</li>
             </ul>
           </div>
@@ -104,7 +104,7 @@
           <div class="col-xs-4 subSection text-center">
             <h4>{{career2.standardized_title}}</h4>
             <ul>
-                <li ng-repeat="skill in skills2 | orderBy: '-count' | limitTo: 20">
+                <li ng-repeat="skill in skills2">
                   {{skill}}</li>
             </ul>
           </div>
@@ -118,26 +118,42 @@
           </div>
 
           <!-- Left Column -->
-          <div class="col-xs-6 subSection border-right col-left">
+          <div class="col-xs-4 subSection text-center">
+            <h4>{{career1.standardized_title}}</h4>
             <ul>
-                <li ng-repeat="category in career1.categories | limitTo: 10" >
+                <li ng-repeat="industry in industries1">
                   <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
-                    {{category.name}}
-                  </a>
+                    {{industry}}
+                  </a>   
+                </li>
+            </ul>
+          </div>
+
+          <!-- Middle Column -->
+          <div class="col-xs-4 subSection text-center" ng-init="intersection = skillIntersection(career1.skills, career2.skills)">
+            <h4>Both Careers</h4>
+            <ul>
+                <li ng-repeat="industry in industriesIntersect">
+                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
+                    {{industry}}
+                  </a>   
                 </li>
             </ul>
           </div>
 
           <!-- Right Column -->
-          <div class="col-xs-6 subSection border-left col-right">
+          <div class="col-xs-4 subSection text-center">
+            <h4>{{career2.standardized_title}}</h4>
             <ul>
-                <li ng-repeat="category in career2.categories | limitTo: 10" >
+                <li ng-repeat="industry in industries2">
                   <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
-                    {{category.name}}
-                  </a>
+                    {{industry}}
+                  </a>   
                 </li>
             </ul>
           </div>
+
+
         </div>
 
         <!-- WORK CONTEXT -->

--- a/client/templates/home-search.ng.html
+++ b/client/templates/home-search.ng.html
@@ -62,8 +62,10 @@
 
   <div class="col-xs-8 col-xs-offset-2 text-center" id="browsingHelp">
 
+    <h2 class="text-center">Not sure what to search for?</h2>
+
     <div class="col-xs-4">
-      <h4>See Popular Careers</h4>
+      <h4>Jump to Popular Careers</h4>
       <ul>
         <li ng-repeat="career in topCareers | limitTo: 5">
           <a href="">{{career}}</a>
@@ -72,7 +74,7 @@
     </div>
 
     <div class="col-xs-4">
-      <h4>Search Top Skills</h4>
+      <h4>Search Careers by Top Skills</h4>
       <ul>
         <li ng-repeat="skill in topSkills | limitTo: 5">
           <a ng-click="setQuery(skill)" aria-label="search for {{skill}}" ui-sref="results({queryString: queryStringURL})">
@@ -83,11 +85,11 @@
     </div>
 
     <div class="col-xs-4">
-      <h4>Search Top Industries</h4>
+      <h4>Search Careers by Top Categories</h4>
       <ul>
-        <li ng-repeat="industry in topIndustries | limitTo: 5">
-          <a ng-click="setQuery(industry)" aria-label="search for {{industry}}" ui-sref="results({queryString: queryStringURL})">
-            {{industry}}
+        <li ng-repeat="category in topCategories | limitTo: 5">
+          <a ng-click="setQuery(category)" aria-label="search for {{category}}" ui-sref="results({queryString: queryStringURL})">
+            {{category}}
           </a>
         </li>
       </ul>

--- a/client/templates/home-search.ng.html
+++ b/client/templates/home-search.ng.html
@@ -38,21 +38,21 @@
   <div class="col-xs-12" id="productDescription">
     <div class="col-xs-10 col-xs-offset-1">
 
-      <h1 class="text-center">Want to change careers? Pivot can help.</h1>
+      <h1 class="text-center">Want to change careers? <span class="textBrand">Pivot can help.</span></h1>
 
       <div class="col-xs-4 productInfo">
         <h4>Find Other Careers</h4>
-        <p>Whether you have a new career in mind or not, Pivot helps you search hundreds of career profiles to find a better career fit for you.</p>
+        <p class="text-justify">Whether you have a new career in mind or not, Pivot helps you search hundreds of career profiles to find a better career fit for you.</p>
       </div>
 
       <div class="col-xs-4 productInfo">
-        <h4>Understand Your Options</h4>
-        <p>Our career profiles are based on data aggregate from thousands of real Bay Area job postings. Explore the data to get a deeper understanding of your options.</p>
+        <h4>Compare Your Options</h4>
+        <p class="text-justify">Our career profiles are based on data aggregated from thousands of real San Francisco Bay Area job postings. Compare careers to understand your options.</p>
       </div>
 
       <div class="col-xs-4 productInfo">
         <h4>Take the Next Step</h4>
-        <p>Prepare for your next career by building new skills and targeting your resume. We'll give you head start for finding free online classess and tips for updating your resume.</p>
+        <p class="text-justify">We'll provide tips for targeting your resume to different careers and point you in the direction of free online classes for building new skills.</p>
       </div>
 
     </div>
@@ -66,6 +66,7 @@
 
     <div class="col-xs-4">
       <h4>Jump to Popular Careers</h4>
+      <br>
       <ul>
         <li ng-repeat="career in topCareers | limitTo: 5">
           <a href="">{{career}}</a>
@@ -75,6 +76,7 @@
 
     <div class="col-xs-4">
       <h4>Search Careers by Top Skills</h4>
+      <br>
       <ul>
         <li ng-repeat="skill in topSkills | limitTo: 5">
           <a ng-click="setQuery(skill)" aria-label="search for {{skill}}" ui-sref="results({queryString: queryStringURL})">
@@ -86,6 +88,7 @@
 
     <div class="col-xs-4">
       <h4>Search Careers by Top Categories</h4>
+      <br>
       <ul>
         <li ng-repeat="category in topCategories | limitTo: 5">
           <a ng-click="setQuery(category)" aria-label="search for {{category}}" ui-sref="results({queryString: queryStringURL})">

--- a/client/templates/home-search.ng.html
+++ b/client/templates/home-search.ng.html
@@ -1,4 +1,4 @@
-<div class="home col-xs-12">
+<div class="home">
 
   <!-- SEARCH BOX CTA -->
 

--- a/client/templates/results.ng.html
+++ b/client/templates/results.ng.html
@@ -98,10 +98,10 @@
             </div>
 
             <div class="tags-wrapper col-xs-8">
-              <h6>Top Industries</h6>
+              <h6>Top Categories</h6>
               <ul>
                 <li ng-repeat="category in career.categories | limitTo: 5">
-                  <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
+                  <a class="categoryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
                     {{category.name}}
                   </a></li>
               </ul>

--- a/client/templates/sidebar.ng.html
+++ b/client/templates/sidebar.ng.html
@@ -6,19 +6,19 @@
 
       <h4 class="cardTitle">
         <span class="fa fa-thumb-tack"></span>
-        Pinned Careers
+        Compare Careers
       </h4>
 
       <div ng-hide="pinnedCareers.length != 0">
-        <p>Click on the pin icon 
-          ( <span class="fa fa-thumb-tack"></span> )
-            to save careers here for later.
+        <p>Click on the pin ( <span class="fa fa-thumb-tack fa-lg"></span> )
+            to save careers here for comparison
         </p>
       </div>
 
       <div ng-hide="pinnedCareers.length == 0">
 
-        <span class="text-center small">select 2 careers to compare</span>
+        <p class="small" ng-show="pinnedCareers.length == 1">pin 1 more career to compare</p>
+        <p class="small" ng-show="pinnedCareers.length >= 2" ng-class="{'text-muted': comparedCareers.length == 2}">select 2 careers to compare</p>
 
         <ul class="sidebarList pinnedList">
           <li ng-repeat="p in pinnedCareers track by p.id" class="text-capitalize">

--- a/client/templates/view-career.ng.html
+++ b/client/templates/view-career.ng.html
@@ -107,11 +107,11 @@
               <li ng-repeat="context in career.work_context.top_work_contexts | limitTo: contextLimit" class="longListItem">
                 {{context}}</li>
             </ul>
-            <a role="button" class="showMoreCareerInfo" ng-hide="career.work_context.top_work_contexts.length <= contextLimit" ng-click="contextLimit = career.work_activities.activities.length">
+            <a role="button" class="showMoreCareerInfo" ng-hide="career.work_context.top_work_contexts.length <= contextLimit" ng-click="contextLimit = 20">
               show more
               <span class="fa fa-chevron-down"></span>
             </a>
-            <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit === career.work_activities.activities.length" ng-click="contextLimit = 4">
+            <a href="#anchor-context" role="button" class="showMoreCareerInfo" ng-show="contextLimit == 20" ng-click="contextLimit = 4">
               show less
               <span class="fa fa-chevron-up"></span>
             </a>

--- a/client/templates/view-career.ng.html
+++ b/client/templates/view-career.ng.html
@@ -124,11 +124,11 @@
             <h5>Learn More <br>
               About This Career</h5>
             <span>
-              Check out  
+              Check out 
               <a href="http://www.onetonline.org/link/summary/{{career.onet_code[0]}}" target="_blank">
                 O*Net Online
               </a>
-              for more information.
+              to explore the government's data for this career.
             </span>
           </div>
 
@@ -256,7 +256,7 @@
               <a href="http://www.meetup.com/find/?allMeetups=false&keywords={{ career.standardized_title }}&radius=50&userFreeform=san+francisco%2C+ca" target="_blank">
                 Meetup.com
               </a>
-               to meet other people interested in this career.
+               to meet people in this career.
             </span>
           </div>
         
@@ -264,8 +264,8 @@
 
             <div class="col-xs-12">
               <h5>RESUME KEYWORDS</h5>
-              <p>Use these top words drawn from <strong>{{career.job_ids.length}}</strong> 
-              {{career.standardized_title}} job postings when updating your resume.</p>
+              <p>Update your resume with these top words drawn from <strong>{{career.job_ids.length}}</strong> 
+              job postings for <strong>{{career.standardized_title}}</strong>.</p>
             </div>
 
             <!-- <div class="col-xs-12"></div> -->

--- a/client/templates/view-career.ng.html
+++ b/client/templates/view-career.ng.html
@@ -48,6 +48,9 @@
 
         <div class="col-xs-7 subSection" ng-init="skillLimit = 10">
           <h5 class="anchor" id="anchor-skills">SKILLS</h5>
+
+          <small><i>Percentage of <strong>{{career.job_ids.length }}</strong> job postings for <strong>{{career.standardized_title}}</strong> that included these skills</i></small> <br> <br>
+
           <ul>
             <li ng-repeat="skill in career.skills | orderBy: '-count' | limitTo: skillLimit">
               <table>
@@ -87,10 +90,10 @@
         </div>
 
         <div class="tags-wrapper col-xs-7 subSection">
-          <h5>INDUSTRIES</h5>
+          <h5>CATEGORIES</h5>
           <ul>
             <li ng-repeat="category in career.categories | limitTo: 10" >
-              <a class="industryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
+              <a class="categoryTag colorTransFast" ng-click="setQuery(category.name)" aria-label="search for {{category.name}}" ui-sref="results({queryString: queryStringURL})">
                 {{category.name}}
               </a>
             </li>

--- a/style/style.less
+++ b/style/style.less
@@ -55,6 +55,10 @@ li {
   visibility: hidden;
 }*/
 
+.textBrand {
+  color: @brand-secondary;
+}
+
 // Nav Search 
 .nav-search {
   width: 600px;
@@ -76,6 +80,14 @@ li {
 .home h2, .home h1 {
   padding-bottom: @padding-base-horizontal*2;
   font-weight: normal;
+}
+
+.home p {
+  line-height: 1.45;
+}
+
+.home li {
+  padding-bottom: @padding-base-vertical*2;
 }
 
 #cta-search-box {

--- a/style/style.less
+++ b/style/style.less
@@ -148,6 +148,13 @@ a {
   box-shadow: 0px 2px 6px @gray-light;
 }
 
+.navbar a:hover {
+  border: none;
+}
+
+.nav-search {
+  margin-bottom: 10px;
+}
 
 // Vertical Dividers
 

--- a/style/style.less
+++ b/style/style.less
@@ -309,7 +309,7 @@ a {
   display: inline-block;
 }
 
-.industryTag {
+.categoryTag {
   background-color: @brand-primary-lighter;
   font-size: @font-size-small;
   line-height: 3;
@@ -318,7 +318,7 @@ a {
   border-radius: @border-radius-small;
 }
 
-.industryTag:hover {
+.categoryTag:hover {
   background-color: @brand-primary-light;
   /*border-bottom: 1px solid @brand-primary;*/
 }

--- a/style/vendor/custom.bootstrap.import.less
+++ b/style/vendor/custom.bootstrap.import.less
@@ -368,7 +368,7 @@
 //##
 
 // Basics of a navbar
-@navbar-height:                    50px;
+@navbar-height:                    53px;
 @navbar-margin-bottom:             @line-height-computed;
 @navbar-border-radius:             @border-radius-base;
 @navbar-padding-horizontal:        floor((@grid-gutter-width / 2));


### PR DESCRIPTION
Compare View
- industries intersect venn
  - zero state on intersect when no shared industries
- default shows 3 activities
- update message in 'no data' boxes
- work context intersect venn
  - hide intersect and show 2-column view if any O*net data is missing

Career View
- fix but for show more / less
- revised wording for meetups intro, resume keywords intro, and O*net learn more link

Sidebar
- renamed to 'compare careers'
  - different compare help text when 1 career is pinned
  - mute compare help text when 2 careers selected

Misc.
- replaced 'industry' with 'category' throughout templates, html, style css, and controllers
- updated homepage description of Pivot
- navbar height consistency between home and nav-search views
