### PR TITLE
Improved regex patterns for search

### DIFF
--- a/lib/collections.js
+++ b/lib/collections.js
@@ -1,4 +1,4 @@
-// Jobs = new Mongo.Collection('jobs');
+Jobs = new Mongo.Collection('jobs');
 Careers = new Mongo.Collection('careers');
 CareerSearch = new Mongo.Collection('careerSearch');
 Autocomplete = new Mongo.Collection('autocomplete');
@@ -10,28 +10,38 @@ _ = lodash;
 
 if (Meteor.isServer){
 
-    // Meteor.publish('jobs', function(){
-    //     return Jobs.find({}, {fields: {job_id: 1, skills: 1} });
-    // });
+    Meteor.publish('jobs', function(){
+        return Jobs.find({}, {fields: {job_id: 1, skills: 1} });
+    });
 
     Meteor.publish('careerResults', function(options, searchString){
 
         sub = this;
 
+        // exit publish function if searchString is null
+        if(searchString == null){
+            return;
+        } else {
+           var searchString = searchString.toLowerCase()
+        }
+
+        // split on any number of consecutive whitespace if the string has a length
+        var splitString = (searchString != null) ? searchString.split(/\s+/) : [''];
+        var regexString = new RegExp(splitString.join('|'));
+
         results =  Careers.aggregate([
                             {$match: 
                                 {$or: [
-                                    {standardized_title : { $regex : searchString, $options : 'i'}},
-                                        {'job_titles.name' : { $regex : searchString, $options : 'i'}},
-                                        {'categories.name' : { $regex : searchString, $options : 'i'}},
-                                        {'skills.name' : { $regex : searchString, $options : 'i'}},
-                                        {'work_activities.activities' : { $regex : searchString, $options : 'i'}},
-                                        {'knowledge.name' : { $regex : searchString, $options : 'i'}}
+                                        {'standardized_title' : { $regex : regexString, $options : 'i'}},
+                                        {'job_titles.name' : { $regex : regexString, $options : 'i'}},
+                                        {'categories.name' : { $regex : regexString, $options : 'i'}},
+                                        {'skills.name' : { $regex : regexString, $options : 'i'}},
+                                        {'work_activities.activities' : { $regex : regexString, $options : 'i'}},
+                                        {'knowledge.name' : { $regex : regexString, $options : 'i'}}
                                     ]
                                 }
                             },
-
-                    ]);
+                        ]);
 
         
         var getScore = function(career, query) {
@@ -42,32 +52,88 @@ if (Meteor.isServer){
             var workActSum = 0;
             var knowledgeSum = 0;
 
+            // whole term on word boundaries
+            var queryRegExp = new RegExp('\\b' + query + '\\b', 'i');
 
-            var queryRegExp = new RegExp(query, 'i');
 
-            if(queryRegExp.test(career.standardized_title)) {
+            // CAREER TITLE
+            // if whole query exactly matches a career title, add 2 points
+            if(query == career.standardized_title.toLowerCase()) {
+                careerTitleSum += 2;
+            // if whole query exactly matches a whole word in the career title, add 1 point
+            } else if (queryRegExp.test(career.standardized_title)) {
                 careerTitleSum += 1;
             }
 
+            // JOB TITLE
             _(career.job_titles).each(function(title) {
-                if(_.contains(title.name, query)){
+
+                // if whole query exactly matches a job title, add count for that title
+                if(title.name.toLowerCase() == query) {
                     jobTitleSum += title.count;
+                    // console.log('TITLE Whole phrase: ', career.standardized_title, title.name, jobTitleSum);
+                } else {
+                    _(splitString).each(function(term) {
+
+                        termRegExp = new RegExp('\\b' + term + '\\b', 'i');
+
+                        // if this word in the query exactly matches a whole word in the job title, 
+                        // add the count normalized by the number of words in the query and title
+                        if (termRegExp.test(title.name)) {
+                            jobTitleSum += (title.count / title.name.split(/\s+/).length) / (splitString.length);
+                            // console.log('TITLE A word: ', career.standardized_title, title.name, jobTitleSum);
+                        }
+                    });
                 }
             });
 
+            // INDUSTRY / CATEGORY
             _(career.categories).each(function(industry) {
-                if(_.contains(industry.name, query)){
+
+                // if whole query exactly matches a category, add count for that title
+                if(industry.name.toLowerCase() == query) {
                     industrySum += industry.count;
+                    // console.log('INDUSTRY Whole phrase: ', career.standardized_title, industry.name, industrySum);
+                } else {
+                    _(splitString).each(function(term) {
+
+                        termRegExp = new RegExp('\\b' + term + '\\b', 'i');
+
+                        // if this word in the query exactly matches a whole word in the industry name, 
+                        // add the count normalized by the number of words in the query and industry
+                        if (termRegExp.test(industry.name)) {
+                            industrySum += (industry.count / industry.name.split(/\s+/).length) / (splitString.length);
+                            // console.log('INDUSTRY A word: ', career.standardized_title, industry.name, skillSum);
+                        }
+                    });
                 }
             });
 
 
+            // SKILLS
             _(career.skills).each(function(skill) {
-                if(_.contains(skill.name, query)){
+
+                // if whole query exactly matches a skill, add count for that title
+                if(skill.name.toLowerCase() == query) {
                     skillSum += skill.count;
+                    // console.log('SKILL Whole phrase: ', career.standardized_title, skill.name, skillSum);
+                } else {
+                    _(splitString).each(function(term) {
+
+                        termRegExp = new RegExp('\\b' + term + '\\b', 'i');
+
+                        // if this word in the query exactly matches a whole word in the skill name, 
+                        // add the count normalized by the number of words in the query and skill
+                        if (termRegExp.test(skill.name)) {
+                            skillSum += (skill.count / skill.name.split(/\s+/).length) / (splitString.length);
+                            // console.log('SKILL A word: ', career.standardized_title, skill.name, skillSum);
+                        }
+                    });
                 }
             });
 
+
+            // WORK ACTIVITIES
             if(career.work_activities != null) {
                 _(career.work_activities.activities).each(function(activity) {
                     if(queryRegExp.test(activity)){
@@ -76,6 +142,8 @@ if (Meteor.isServer){
                 });
             }
 
+
+            // KNOWLEDGE
             if(career.knowledge != null) {
                 _(career.knowledge).each(function(k) {
                     if(queryRegExp.test(k.name)){
@@ -88,8 +156,7 @@ if (Meteor.isServer){
             var jobCount = career.num_ids;
 
             score = careerTitleSum  + knowledgeSum + workActSum +
-                    (( jobTitleSum/jobCount + skillSum/jobCount + industrySum/jobCount) * jobCount/17692 * 0.5); // scale by prevalence in jobs collection
-
+                    (( jobTitleSum/jobCount + skillSum/jobCount + industrySum/jobCount) * jobCount/16064); // scale by prevalence in jobs collection
 
             return score;
         }
@@ -374,10 +441,10 @@ function processJobData() {
 
         // INSERT DATA INTO COLLECTIONS
 
-        // _.each(jobs, function(job) {
-        // 	Jobs.insert(job);
-        // });
-        // console.log('Done importing Jobs');
+        _.each(jobs, function(job) {
+        	Jobs.insert(job);
+        });
+        console.log('Done importing Jobs');
 
         _.each(careers, function(career) {
         	Careers.insert(career);

--- a/lib/collections.js
+++ b/lib/collections.js
@@ -1,4 +1,4 @@
-Jobs = new Mongo.Collection('jobs');
+// Jobs = new Mongo.Collection('jobs');
 Careers = new Mongo.Collection('careers');
 CareerSearch = new Mongo.Collection('careerSearch');
 Autocomplete = new Mongo.Collection('autocomplete');
@@ -10,9 +10,9 @@ _ = lodash;
 
 if (Meteor.isServer){
 
-    Meteor.publish('jobs', function(){
-        return Jobs.find({}, {fields: {job_id: 1, skills: 1} });
-    });
+    // Meteor.publish('jobs', function(){
+    //     return Jobs.find({}, {fields: {job_id: 1, skills: 1} });
+    // });
 
     Meteor.publish('careerResults', function(options, searchString){
 
@@ -226,10 +226,6 @@ if (Meteor.isServer){
     });
 
 
-    // Meteor.publish('skills', function() {
-    //     return Skills.find({}, {fields: {name: 1}});
-    // })
-
     Meteor.publish('careerProfileResults', function(careerId){
         return Careers.find(careerId);
     });
@@ -242,9 +238,6 @@ if (Meteor.isServer){
         return Careers.find({_id:{$in: [careerId1, careerId2]}});
     });
 
-    // Meteor.publish('skills', function(){
-    //     return Skills.find({});
-    // });
 
     Careers.allow({
         insert: function(){
@@ -254,21 +247,7 @@ if (Meteor.isServer){
             return true;
         }
     });
-
-    // Jobs.allow({
-    // 	insert: function() {
-    // 		return true;
-    // 	}
-    // });
-
-    // Skills.allow({
-    // 	insert: function() {
-    // 		return true;
-    // 	},
-    // 	update: function(){
-    //         return true;
-    //     }
-    // });
+    
 
     Meteor.startup(function () {
         Meteor.call('processJobData');
@@ -441,10 +420,10 @@ function processJobData() {
 
         // INSERT DATA INTO COLLECTIONS
 
-        _.each(jobs, function(job) {
-        	Jobs.insert(job);
-        });
-        console.log('Done importing Jobs');
+        // _.each(jobs, function(job) {
+        // 	Jobs.insert(job);
+        // });
+        // console.log('Done importing Jobs');
 
         _.each(careers, function(career) {
         	Careers.insert(career);


### PR DESCRIPTION
Initial match regex in mongo $match query now returns careers that have any of the input search terms (separated on white space). For example, the query "javascript python" will return careers that have at least one of these terms across target strings (skills, job titles, etc.).

The ranking algorithm gives the highest score if the whole query is equal to the target string. Some points are awarded for each entire term in the query (separated on word boundaries) overlaps with entire words from the target string.

I also updated the score weighting to normalize by the updated number of job descriptions included.
